### PR TITLE
Initial HPA Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY hooks/ hooks/
+COPY metrics/ metrics/
 COPY pkg/ pkg/
 COPY util/ util/
 COPY webhooks/ webhooks/

--- a/Tiltfile
+++ b/Tiltfile
@@ -27,6 +27,7 @@ local_resource("octorun-manifest",
                labels=[])
 
 manager_deps.append("hooks")
+manager_deps.append("metrics")
 manager_deps.append("pkg")
 manager_deps.append("util")
 local_resource("octorun-manager-binary",

--- a/api/v1alpha1/runnerset_types.go
+++ b/api/v1alpha1/runnerset_types.go
@@ -64,11 +64,17 @@ type RunnerSetStatus struct {
 	// Conditions defines current service state of the runner.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// Selector is the same as the label selector but in the string format to avoid introspection
+	// by clients. The string will be in the same format as the query-param syntax.
+	// More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+	// +optional
+	Selector string `json:"selector,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.runners,statuspath=.status.runners
+// +kubebuilder:subresource:scale:specpath=.spec.runners,statuspath=.status.runners,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Runners",type="integer",description="Represents the current number of the runner.",JSONPath=".status.runners"
 // +kubebuilder:printcolumn:name="Idle",type="integer",description="Represents the current number of the idle runner.",JSONPath=".status.idleRunners"
 // +kubebuilder:printcolumn:name="Active",type="integer",description="Represents the current number of the active runner.",JSONPath=".status.activeRunners"

--- a/config/crd/bases/octorun.github.io_runnersets.yaml
+++ b/config/crd/bases/octorun.github.io_runnersets.yaml
@@ -3177,12 +3177,19 @@ spec:
                 description: Runners is the most recently observed number of runners.
                 format: int32
                 type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
             type: object
         type: object
     served: true
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.runners
         statusReplicasPath: .status.runners
       status: {}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
+      honorLabels: true
+      relabelings:
+      - action: labeldrop
+        regex: (pod|service|endpoint|namespace)
       port: https
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,18 +1,14 @@
 resources:
-# All RBAC will be applied under this service account in
-# the deployment namespace. You may comment out this resource
-# if your manager will use a service account that exists at
-# runtime. Be sure to update RoleBinding and ClusterRoleBinding
-# subjects if changing service account names.
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
-# Comment the following 4 lines if you want to disable
-# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
-# which protects your /metrics endpoint.
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- runner_editor_role.yaml
+- runner_viewer_role.yaml
+- runnerset_editor_role.yaml
+- runnerset_viewer_role.yaml

--- a/controllers/runnerset_controller.go
+++ b/controllers/runnerset_controller.go
@@ -83,6 +83,11 @@ func (r *RunnerSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}()
 
+	selector, err := metav1.LabelSelectorAsSelector(&runnerset.Spec.Selector)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	runners, err := r.findRunners(ctx, runnerset)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -96,6 +101,7 @@ func (r *RunnerSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	runnerset.Status.Selector = selector.String()
 	return ctrl.Result{}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -48,7 +49,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/metrics/docs.go
+++ b/metrics/docs.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics contains statemetrics.Provider implementations.
+package metrics

--- a/metrics/runner_metric.go
+++ b/metrics/runner_metric.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2022 The Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	octorunv1alpha1 "octorun.github.io/octorun/api/v1alpha1"
+	"octorun.github.io/octorun/pkg/statemetrics"
+)
+
+type RunnerProvider struct{}
+
+func (p *RunnerProvider) Namespace() string { return "octorun" }
+func (p *RunnerProvider) Subsystem() string { return "runner" }
+func (p *RunnerProvider) ProvideMetricFamily() []statemetrics.MetricFamily {
+	return []statemetrics.MetricFamily{
+		{
+			Name: "labels",
+			Help: "Kubernetes labels converted to Prometheus labels.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(r *octorunv1alpha1.Runner) []*statemetrics.Metric {
+				k, v := MapToPrometheusLabels("label", r.Labels)
+				return []*statemetrics.Metric{
+					{
+						LabelKeys:   k,
+						LabelValues: v,
+						Value:       1,
+					},
+				}
+			}),
+		},
+		{
+			Name: "created",
+			Help: "Unix creation timestamp",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(r *octorunv1alpha1.Runner) []*statemetrics.Metric {
+				metrics := []*statemetrics.Metric{}
+				if !r.CreationTimestamp.IsZero() {
+					metrics = append(metrics, &statemetrics.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(r.CreationTimestamp.Unix()),
+					})
+				}
+
+				return metrics
+			}),
+		},
+		{
+			Name: "status_phase",
+			Help: "Current status phase.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(r *octorunv1alpha1.Runner) []*statemetrics.Metric {
+				phase := r.Status.Phase
+				if phase == "" {
+					return []*statemetrics.Metric{}
+				}
+
+				phases := []struct {
+					met      bool
+					strphase string
+				}{
+					{phase == octorunv1alpha1.RunnerPendingPhase, string(octorunv1alpha1.RunnerPendingPhase)},
+					{phase == octorunv1alpha1.RunnerIdlePhase, string(octorunv1alpha1.RunnerIdlePhase)},
+					{phase == octorunv1alpha1.RunnerActivePhase, string(octorunv1alpha1.RunnerActivePhase)},
+					{phase == octorunv1alpha1.RunnerCompletePhase, string(octorunv1alpha1.RunnerCompletePhase)},
+				}
+
+				metrics := make([]*statemetrics.Metric, len(phases))
+				for i, p := range phases {
+					metrics[i] = &statemetrics.Metric{
+
+						LabelKeys:   []string{"phase"},
+						LabelValues: []string{p.strphase},
+						Value:       BoolFloat64(p.met),
+					}
+				}
+
+				return metrics
+			}),
+		},
+		{
+			Name: "status_conditions",
+			Help: "Current status conditions.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(r *octorunv1alpha1.Runner) []*statemetrics.Metric {
+				return MetaConditionsMetrics(r.Status.Conditions)
+			}),
+		},
+	}
+}
+
+func (p *RunnerProvider) Lister(ctx context.Context, r client.Reader) cache.Lister {
+	return &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			runnerList := &octorunv1alpha1.RunnerList{}
+			err := r.List(ctx, runnerList, &client.ListOptions{Raw: &options})
+			return runnerList, err
+		},
+	}
+}
+
+func (p *RunnerProvider) WrapMetricsFunc(fn func(*octorunv1alpha1.Runner) []*statemetrics.Metric) func(runtime.Object) []*statemetrics.Metric {
+	return func(obj runtime.Object) []*statemetrics.Metric {
+		runner := obj.(*octorunv1alpha1.Runner)
+		metrics := fn(runner)
+		for _, m := range metrics {
+			m.LabelKeys = append([]string{"namespace", "runner"}, m.LabelKeys...)
+			m.LabelValues = append([]string{runner.Namespace, runner.Name}, m.LabelValues...)
+		}
+
+		return metrics
+	}
+}

--- a/metrics/runnerset_metric.go
+++ b/metrics/runnerset_metric.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2022 The Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	octorunv1alpha1 "octorun.github.io/octorun/api/v1alpha1"
+	"octorun.github.io/octorun/pkg/statemetrics"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type RunnerSetProvider struct{}
+
+func (p *RunnerSetProvider) Namespace() string { return "octorun" }
+func (p *RunnerSetProvider) Subsystem() string { return "runnerset" }
+func (p *RunnerSetProvider) ProvideMetricFamily() []statemetrics.MetricFamily {
+	return []statemetrics.MetricFamily{
+		{
+			Name: "labels",
+			Help: "Kubernetes labels converted to Prometheus labels.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				k, v := MapToPrometheusLabels("label", rs.Labels)
+				return []*statemetrics.Metric{
+					{
+						LabelKeys:   k,
+						LabelValues: v,
+						Value:       1,
+					},
+				}
+			}),
+		},
+		{
+			Name: "created",
+			Help: "Unix creation timestamp",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				metrics := []*statemetrics.Metric{}
+				if !rs.CreationTimestamp.IsZero() {
+					metrics = append(metrics, &statemetrics.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(rs.CreationTimestamp.Unix()),
+					})
+				}
+
+				return metrics
+			}),
+		},
+		{
+			Name: "spec_runners",
+			Help: "Number of desired runners.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				metrics := []*statemetrics.Metric{}
+				if rs.Spec.Runners != nil {
+					metrics = append(metrics, &statemetrics.Metric{
+						Value: float64(*rs.Spec.Runners),
+					})
+				}
+
+				return metrics
+			}),
+		},
+		{
+			Name: "status_runners",
+			Help: "Most recently observed number of runners.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				metrics := []*statemetrics.Metric{}
+				if rs.Spec.Runners != nil {
+					metrics = append(metrics, &statemetrics.Metric{
+						Value: float64(rs.Status.Runners),
+					})
+				}
+
+				return metrics
+			}),
+		},
+		{
+			Name: "status_idle_runners",
+			Help: "Most recently observed number of idle runners.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				metrics := []*statemetrics.Metric{}
+				if rs.Spec.Runners != nil {
+					metrics = append(metrics, &statemetrics.Metric{
+						Value: float64(rs.Status.IdleRunners),
+					})
+				}
+
+				return metrics
+			}),
+		},
+		{
+			Name: "status_active_runners",
+			Help: "Most recently observed number of active runners.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				metrics := []*statemetrics.Metric{}
+				if rs.Spec.Runners != nil {
+					metrics = append(metrics, &statemetrics.Metric{
+						Value: float64(rs.Status.ActiveRunners),
+					})
+				}
+
+				return metrics
+			}),
+		},
+		{
+			Name: "status_conditions",
+			Help: "Current status conditions.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				return MetaConditionsMetrics(rs.Status.Conditions)
+			}),
+		},
+		{
+			Name: "runner_active_ratio",
+			Help: "Ratio of active runners per total runners.",
+			Type: prometheus.GaugeValue,
+			MetricsFunc: p.WrapMetricsFunc(func(rs *octorunv1alpha1.RunnerSet) []*statemetrics.Metric {
+				metrics := []*statemetrics.Metric{}
+				x := float64(rs.Status.ActiveRunners) / float64(rs.Status.Runners)
+				v := int(x * 100)
+				if rs.Spec.Runners != nil {
+					metrics = append(metrics, &statemetrics.Metric{
+						Value: float64(v) / 100,
+					})
+				}
+
+				return metrics
+			}),
+		},
+	}
+}
+
+func (p *RunnerSetProvider) Lister(ctx context.Context, r client.Reader) cache.Lister {
+	return &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			runnersetList := &octorunv1alpha1.RunnerSetList{}
+			err := r.List(ctx, runnersetList, &client.ListOptions{Raw: &options})
+			return runnersetList, err
+		},
+	}
+}
+
+func (p *RunnerSetProvider) WrapMetricsFunc(fn func(*octorunv1alpha1.RunnerSet) []*statemetrics.Metric) func(runtime.Object) []*statemetrics.Metric {
+	return func(obj runtime.Object) []*statemetrics.Metric {
+		runnerset := obj.(*octorunv1alpha1.RunnerSet)
+		metrics := fn(runnerset)
+		for _, m := range metrics {
+			m.LabelKeys = append([]string{"namespace", "runnerset"}, m.LabelKeys...)
+			m.LabelValues = append([]string{runnerset.Namespace, runnerset.Name}, m.LabelValues...)
+		}
+
+		return metrics
+	}
+}

--- a/metrics/util.go
+++ b/metrics/util.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"octorun.github.io/octorun/pkg/statemetrics"
+)
+
+var (
+	conditionStatuses = []metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionFalse, metav1.ConditionUnknown}
+)
+
+// BoolFloat64 returns 1 if true and 0
+// otherwise from given boolean value.
+func BoolFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+
+	return 0
+}
+
+// MetaConditionsMetrics returns metrics from given slice of metav1.Condition
+func MetaConditionsMetrics(conditions []metav1.Condition) []*statemetrics.Metric {
+	metrics := make([]*statemetrics.Metric, len(conditions)*len(conditionStatuses))
+	for i, c := range conditions {
+		conditionMetrics := make([]*statemetrics.Metric, len(conditionStatuses))
+		for i, status := range conditionStatuses {
+			conditionMetrics[i] = &statemetrics.Metric{
+				LabelValues: []string{strings.ToLower(string(status))},
+				Value:       BoolFloat64(c.Status == status),
+			}
+		}
+
+		for j, cm := range conditionMetrics {
+			selectedMetric := cm
+			selectedMetric.LabelKeys = []string{"condition", "status"}
+			selectedMetric.LabelValues = append([]string{c.Type}, selectedMetric.LabelValues...)
+			metrics[i*len(conditionStatuses)+j] = selectedMetric
+		}
+	}
+
+	return metrics
+}
+
+// MapToKeysValuesLabels returns slice of keys and values prometheus labels.
+func MapToPrometheusLabels(prefix string, m map[string]string) ([]string, []string) {
+	keys := make([]string, 0, len(m))
+	values := make([]string, 0, len(m))
+	sortedKeys := make([]string, 0)
+	for k := range m {
+		sortedKeys = append(sortedKeys, k)
+	}
+
+	sort.Strings(sortedKeys)
+	for _, k := range sortedKeys {
+		key := normalizeLabelName(prefix, k)
+		keys = append(keys, key)
+		values = append(values, m[k])
+	}
+
+	return keys, values
+}
+
+func sanitizeLabelName(s string) string {
+	return regexp.MustCompile(`[^a-zA-Z0-9_]`).ReplaceAllString(s, "_")
+}
+
+func normalizeLabelName(prefix, s string) string {
+	sanitized := sanitizeLabelName(s)
+	snake := regexp.MustCompile("([a-z0-9])([A-Z])").ReplaceAllString(sanitized, "${1}_${2}")
+	return prefix + "_" + strings.ToLower(snake)
+}

--- a/pkg/statemetrics/docs.go
+++ b/pkg/statemetrics/docs.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package statemetrics is library contains interface and utilities to expose
+// prometheus metrics for Kubernetes Resources state.
+//
+// The interface is inspired by how k8s.io/kube-state-metrics provides
+// state metrics for Kubernetes Custom Resources. This library uses
+// prometheus.Collector interface to write the metrics instead of using
+// the own writer generator as k8s.io/kube-state-metrics do.
+// That makes this library compatible with Prometheus Registry
+package statemetrics

--- a/pkg/statemetrics/statemetrics.go
+++ b/pkg/statemetrics/statemetrics.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statemetrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = ctrl.Log.WithName("statemetrics")
+
+// Metric represents a single time series.
+type Metric struct {
+	// LabelKeys list of prometheus label keys.
+	LabelKeys []string
+
+	// LabelValues list of prometheus label values.
+	LabelValues []string
+
+	// Value is prometheus metric value.
+	Value float64
+}
+
+// MetricFamily represents a set of metrics with the same name and help text.
+type MetricFamily struct {
+	// Name is name of metrics
+	Name string
+
+	// Help provides information about this metric.
+	Help string
+
+	// Type is prometheus metric types.
+	Type prometheus.ValueType
+
+	// MetricsFunc knowns how to provide the metrics from given Kubernetes Object.
+	MetricsFunc func(obj runtime.Object) []*Metric
+}
+
+// Provider knowns how to construct and scrape the metrics.
+type Provider interface {
+	// Namespace returns the prometheus namespace of this provider.
+	Namespace() string
+
+	// Subsystem returns the prometheus subsystem of this provider.
+	Subsystem() string
+
+	// ProvideMetricFamily returns slice of MetricFamily.
+	ProvideMetricFamily() []MetricFamily
+
+	// Lister knowns how to fetch list of Kubernetes Objects.
+	Lister(ctx context.Context, r client.Reader) cache.Lister
+}
+
+// Collector collects prometheus metrics from given providers
+type Collector struct {
+	// APIReader is a controller-runtime client.Reader
+	// that configured to uses the API server instead of cache.
+	APIReader client.Reader
+
+	// CacheReader is a controller-runtime client.Reader
+	// that configured to uses controller-runtime cache.
+	CacheReader client.Reader
+
+	// providers holds registered metric providers.
+	providers []Provider
+}
+
+func NewCollector(mgr ctrl.Manager, providers ...Provider) *Collector {
+	return &Collector{
+		APIReader:   mgr.GetAPIReader(),
+		CacheReader: mgr.GetCache(),
+		providers:   providers,
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ctx := context.Background()
+	for _, provider := range c.providers {
+		for _, metric := range c.Scrape(ctx, c.APIReader, provider) {
+			ch <- metric.Desc()
+		}
+	}
+}
+
+// Collect implements prometheus.Collector.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+	for _, provider := range c.providers {
+		for _, metric := range c.Scrape(ctx, c.CacheReader, provider) {
+			ch <- metric
+		}
+	}
+}
+
+// Scrape scrapes the metrics from the given provider. The reader
+// may be given from either APIReader or CacheReader.
+func (c *Collector) Scrape(ctx context.Context, reader client.Reader, provider Provider) []prometheus.Metric {
+	var metrics []prometheus.Metric
+	objList, err := provider.Lister(ctx, reader).List(metav1.ListOptions{})
+	if err != nil {
+		log.Error(err, "unable to fetch Resources")
+		// TODO: collect fail scrape metric instead
+		return nil
+	}
+
+	objs, err := meta.ExtractList(objList)
+	if err != nil {
+		log.Error(err, "unable to fetch Resources")
+		// TODO: collect fail scrape metric instead
+		return nil
+	}
+
+	for _, p := range provider.ProvideMetricFamily() {
+		metricName := prometheus.BuildFQName(provider.Namespace(), provider.Subsystem(), p.Name)
+		for _, obj := range objs {
+			for _, m := range p.MetricsFunc(obj) {
+				metrics = append(metrics, prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName, p.Help, m.LabelKeys, nil),
+					p.Type,
+					m.Value,
+					m.LabelValues...,
+				))
+			}
+		}
+	}
+
+	return metrics
+}


### PR DESCRIPTION
Initial `HorizontalPodAutoscaler` support for `RunnerSet` via [custom.metrics.k8s.io](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/custom-metrics-api.md). The implementation is by exposing `RunnerSet` state metric called `octorun_runnerset_runner_active_ratio` collected by Prometheus and then converted by [prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter) into Kubernetes metric series.

The example RunnerSet with HPA
```yaml
apiVersion: octorun.github.io/v1alpha1
kind: RunnerSet
metadata:
  name: runnerset-sample
  labels:
    octorun.github.io/runnerset: myrunnerset
spec:
  runners: 3
  selector:
    matchLabels:
      octorun.github.io/runnerset: myrunnerset
  template:
    metadata:
      labels:
        octorun.github.io/runnerset: myrunnerset
    spec:
      url: https://github.com/octorun/test-repo
      image:
        name: ghcr.io/octorun/runner:v2.288.1
---
apiVersion: autoscaling/v2beta2
kind: HorizontalPodAutoscaler
metadata:
  name: runnerset-sample-autoscaler
  labels:
    octorun.github.io/runnerset: myrunnerset
spec:
  scaleTargetRef:
    apiVersion: octorun.github.io/v1alpha1
    kind: RunnerSet
    name: runnerset-sample
  minReplicas: 1
  maxReplicas: 10
  metrics:
  - type: Object
    object:
      metric:
        name: octorun_runnerset_runner_active_ratio
      describedObject:
        apiVersion: octorun.github.io/v1alpha1
        kind: RunnerSet
        name: runnerset-sample
      target:
        type: Value
        value: 600m
```
