### PR TITLE
feat: respect Kubernetes autoscaler drain

### DIFF
--- a/.github/workflows/manager.yml
+++ b/.github/workflows/manager.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.48.0
   test:
     runs-on: ubuntu-20.04
     needs: [build]

--- a/api/v1alpha1/well_known_annotations.go
+++ b/api/v1alpha1/well_known_annotations.go
@@ -25,4 +25,14 @@ const (
 	// AnnotationRunnerTokenExpiresAt is used to note when the registration token will expire.
 	// The runner controller will refresh the token if needed based on this annotation.
 	AnnotationRunnerTokenExpiresAt = "runner.octorun.github.io/token-expires-at"
+
+	// AnnotationRunnerEvictionPolicy used to respect the Kubernetes cluster-autoscaler eviction.
+	// Since the Pod created by Runner is not controlled by Kubernetes workload controller (eg: ReplicaSet, StatefulSet etc)
+	// cluster-autoscaler unable to drain underutilized node.
+	//
+	// The value could be Never or IfNotActive. set this annotation to IfNotActive will annotate the runner Pod
+	// with `cluster-autoscaler.kubernetes.io/safe-to-evict=true` once created and will be removed when Runner become Active (has assigned job)
+	//
+	// NOTE: this annotation is experimental and will be added to Runner Object field if possible in the next API version.
+	AnnotationRunnerEvictionPolicy = "runner.octorun.github.io/eviction-policy"
 )

--- a/pkg/github/webhook/server.go
+++ b/pkg/github/webhook/server.go
@@ -62,7 +62,7 @@ func (s *Server) Start(ctx context.Context) error {
 		return err
 	}
 
-	srv := http.Server{
+	srv := http.Server{ //nolint:gosec // TODO(prksu): Fix this
 		Handler: s.mux,
 	}
 


### PR DESCRIPTION
Since the Pod created by Runner is not controlled by Kubernetes workload controller (eg: ReplicaSet, StatefulSet etc) Kubernetes [cluster-autoscaler](https://github.com/kubernetes/autoscaler) unable to drain underutilized node. This PR add ability to the Runner controller to create pod with annotation `cluster-autoscaler.kubernetes.io/safe-to-evict=true` when Runner has annotation `runner.octorun.github.io/eviction-policy=IfNotActive`. When Runner has active phase (given a Job from GitHub) Runner controller will update the runner pod annotation to `cluster-autoscaler.kubernetes.io/safe-to-evict=false` 