### PR TITLE
fix: RunnerSet selector validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ endif
 TEST_FLAGS ?=
 GINKGO_FLAGS ?=
 GINKGO_NOCOLOR ?= false
+GINKGO_FOCUS ?= "RunnerReconciler|RunnerSetReconciler|RunnerWebhook|RunnerSetWebhook"
 
 # Image URL to use all building/pushing image targets
 RELEASE_VERSION	?= main
@@ -99,7 +100,7 @@ test: generate fmt vet ## Run unit tests.
 test-integration: manifests generate fmt vet envtest ginkgo ## Run integration tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" ACK_GINKGO_RC=true $(GINKGO) \
 	-slowSpecThreshold 30 -noColor=$(GINKGO_NOCOLOR) $(GINKGO_FLAGS) \
-	-focus="RunnerReconciler|RunnerSetReconciler|RunnerWebhook|RunnerSetWebhook" \
+	-focus=$(GINKGO_FOCUS) \
 	./controllers/... ./webhooks/...
 
 ##@ Build

--- a/webhooks/runnerset_webhook_test.go
+++ b/webhooks/runnerset_webhook_test.go
@@ -94,6 +94,18 @@ var _ = Describe("RunnerSetWebhook", func() {
 				Expect(crclient.Create(ctx, runnerset)).ToNot(Succeed())
 			})
 		})
+
+		Context("When `selector` does not match template `labels`", func() {
+			newRunnerSet := &octorunv1.RunnerSet{}
+			BeforeEach(func() {
+				runnerset.DeepCopyInto(newRunnerSet)
+				metav1.AddLabelToSelector(&newRunnerSet.Spec.Selector, "foo", "bar")
+			})
+
+			It("Should returns an error", func() {
+				Expect(crclient.Create(ctx, newRunnerSet)).ToNot(Succeed())
+			})
+		})
 	})
 
 	Describe("ValidateUpdate", func() {
@@ -118,6 +130,20 @@ var _ = Describe("RunnerSetWebhook", func() {
 				runnerset.Spec.Template.Spec.URL = "https://google.com/org/repo"
 				By("Updating the RunnerSet")
 				Expect(crclient.Update(ctx, runnerset)).To(HaveOccurred())
+			})
+		})
+
+		Context("When spec selector is updated", func() {
+			It("Should returns an error", func() {
+				By("Creating the RunnerSet")
+				Expect(crclient.Create(ctx, runnerset)).To(Succeed())
+				Expect(crclient.Get(ctx, client.ObjectKeyFromObject(runnerset), runnerset)).ToNot(HaveOccurred())
+
+				newRunnerSet := &octorunv1.RunnerSet{}
+				runnerset.DeepCopyInto(newRunnerSet)
+				metav1.AddLabelToSelector(&newRunnerSet.Spec.Selector, "foo", "bar")
+				By("Updating the RunnerSet")
+				Expect(crclient.Update(ctx, newRunnerSet)).To(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
This PR adds validation for RunnerSet .spec.selector that should be:
1. should match template labels on creation
2. should be immutable after creation #https://github.com/kubernetes/kubernetes/issues/50808